### PR TITLE
modified permissions to support Android 5 (Lollipop) and later

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -12,6 +12,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Hi guys
I found a solution for the issue https://github.com/nickrussler/Android-Wifi-Hotspot-Manager-Class/issues/11. The permissions have heavily changed since Android 5 (Lollipop). Now permissions are also needed to access and change the network state. On my smartphone (Samsung Galaxy Note 1 GT-N7000 Cyanogenmod 13 with ROM http://forum.xda-developers.com/galaxy-note/development/rom-nightowl-alpha1-t3255536) the demo app now works flawless.